### PR TITLE
update server & ip fieldnames

### DIFF
--- a/NordIndicator.py
+++ b/NordIndicator.py
@@ -210,13 +210,13 @@ class NordVPN:
 
                 if 'status' in fieldName:
                     self.status = value
-                elif 'current server' in fieldName:
+                elif 'hostname' in fieldName:
                     self.server = value
                 elif 'country' in fieldName:
                     self.country = value
                 elif 'city' in fieldName:
                     self.city = value
-                elif 'server ip' in fieldName:
+                elif 'ip' in fieldName:
                     self.ip = value
                 elif 'uptime' in fieldName:
                     self.startTime = self.startTimeFromUptime(value)


### PR DESCRIPTION
I'm on Manjaro, everything works perfect but noticed the "Server" & "IP" fields in the menu were not pulling in the data.

I assume Nord updated the names for their CLI from the 'nordvpn status' command you were pulling the data from.

After reinstalling with this update that Server & IP is displaying correctly.